### PR TITLE
Fix for issue: Cannot read property 'hasOwnProperty' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function WebpackClean (
 WebpackClean.prototype.apply = function (compiler) {
   const self = this;
   // eslint-disable-next-line no-prototype-builtins
-  const hasLifecycleHooks = compiler.prototype.hasOwnProperty('hooks'); // Webpack 4.x.x
+  const hasLifecycleHooks = Object.prototype.hasOwnProperty.call(compiler, 'hooks'); // Webpack 4.x.x
   const logErrMsg = 'Files removal aborted due to:';
 
   if (hasLifecycleHooks) {


### PR DESCRIPTION
Looks like this changes were done for ES standards. But its breaking with below error :

TypeError: Cannot read property 'hasOwnProperty' of undefined